### PR TITLE
Move “Static Page Locale Routing” to Settings

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -14,10 +14,10 @@ class Plugin extends \System\Classes\PluginBase
     public function pluginDetails()
     {
         return [
-            'name' => 'Multi-locale customizations',
-            'description' => 'Customizations for RainLab.Translate plugin functionality',
-            'author' => 'Aspen Digital',
-            'icon' => 'icon-pencil'
+            'name'        => 'aspendigital.translate::lang.plugin.name',
+            'description' => 'aspendigital.translate::lang.plugin.description',
+            'author'      => 'Aspen Digital',
+            'icon'        => 'icon-pencil'
         ];
     }
 
@@ -72,8 +72,8 @@ class Plugin extends \System\Classes\PluginBase
     {
         return [
             'settings' => [
-                'label'       => 'Translate',
-                'description' => 'Manage translation options.',
+                'label'       => 'aspendigital.translate::lang.settings.label',
+                'description' => 'aspendigital.translate::lang.settings.description',
                 'icon'        => 'icon-language',
                 'class'       => 'AspenDigital\Translate\Models\Settings',
                 'order'       => 100,
@@ -92,8 +92,8 @@ class Plugin extends \System\Classes\PluginBase
     {
         return [
             'aspendigital.translate.manage_translate_options' => [
-                'tab' => 'Translate',
-                'label' => 'Manage translation options.'
+                'tab'   => 'aspendigital.translate::lang.permission.manage_translate_options.tab',
+                'label' => 'aspendigital.translate::lang.permission.manage_translate_options.label'
             ]
         ];
     }

--- a/Plugin.php
+++ b/Plugin.php
@@ -5,6 +5,7 @@ use Event;
 use RainLab\Translate\Classes\Translator;
 use Response;
 use View;
+use AspenDigital\Translate\Models\Settings as Settings;
 
 class Plugin extends \System\Classes\PluginBase
 {
@@ -27,7 +28,9 @@ class Plugin extends \System\Classes\PluginBase
         // behavior for static pages so if the page doesn't have a URL or markup assigned for the current
         // locale, it's a 404.
         Event::listen('cms.page.beforeDisplay', function($controller, $url, $page) {
-            if (!$page || $url === '/') {
+            $static_page_locale_routing = Settings::get('static_page_locale_routing');
+
+            if (!$static_page_locale_routing || !$page || $url === '/') {
                 return;
             }
 
@@ -58,10 +61,40 @@ class Plugin extends \System\Classes\PluginBase
         });
     }
 
-	public function registerComponents()
-	{
-	    return [
+    public function registerComponents()
+    {
+        return [
             Components\HomeLocalePicker::class => 'homeLocalePicker'
-	    ];
-	}
+        ];
+    }
+
+    public function registerSettings()
+    {
+        return [
+            'settings' => [
+                'label'       => 'Translate',
+                'description' => 'Manage translation options.',
+                'icon'        => 'icon-language',
+                'class'       => 'AspenDigital\Translate\Models\Settings',
+                'order'       => 100,
+                'keywords'    => '',
+                'permissions' => ['aspendigital.translate.manage_translate_options']
+            ]
+        ];
+    }
+
+    /**
+     * Registers any back-end permissions used by this plugin.
+     *
+     * @return array
+     */
+    public function registerPermissions()
+    {
+        return [
+            'aspendigital.translate.manage_translate_options' => [
+                'tab' => 'Translate',
+                'label' => 'Manage translation options.'
+            ]
+        ];
+    }
 }

--- a/Plugin.php
+++ b/Plugin.php
@@ -28,9 +28,9 @@ class Plugin extends \System\Classes\PluginBase
         // behavior for static pages so if the page doesn't have a URL or markup assigned for the current
         // locale, it's a 404.
         Event::listen('cms.page.beforeDisplay', function($controller, $url, $page) {
-            $static_page_locale_routing = Settings::get('static_page_locale_routing');
+            $staticPageLocaleRouting = Settings::get('static_page_locale_routing');
 
-            if (!$static_page_locale_routing || !$page || $url === '/') {
+            if (!$staticPageLocaleRouting || !$page || $url === '/') {
                 return;
             }
 

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ This plugin registers a component named `homeLocalePicker` that can be used in p
 When editing static pages, you will see a `Change Locale` button in the form toolbar. This can be used to change the locale of all translatable fields in the page form.
 
 ## Static Page Locale Routing
-RainLab.Translate falls back to the default locale URL if unassigned in the active locale. This plugin overrides that behavior to return a 404 if a static page does not have a locale URL defined.
+RainLab.Translate falls back to the default locale URL if unassigned in the active locale. This plugin provides an option to override that behavior and return a 404 if a static page does not have a locale URL defined.

--- a/formwidgets/masterlocaleswitcher/partials/_masterlocaleswitcher.htm
+++ b/formwidgets/masterlocaleswitcher/partials/_masterlocaleswitcher.htm
@@ -1,6 +1,8 @@
 <div data-control="master-locale-switcher" style="float: right; display: none">
     <div class="dropdown">
-        <button type="button" data-toggle="dropdown" class="btn button oc-icon-globe">Change Locale</button>
+        <button type="button" data-toggle="dropdown" class="btn button oc-icon-globe">
+          <?= Lang::get('aspendigital.translate::lang.translate.change_locale') ?>
+        </button>
         <ul class="dropdown-menu" role="menu" data-dropdown-title="Locale">
         <?php foreach ($locales as $code => $name): ?>
             <li role="presentation"><a role="menuitem" data-master-locale-switch="<?=$code?>"><?= e($name) ?></a></li>

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -1,0 +1,23 @@
+<?php return [
+    'plugin' => [
+        'name' => 'Multi-locale customizations',
+        'description' => 'Customizations for RainLab.Translate plugin functionality',
+    ],
+    'translate' => [
+        'change_locale' => 'Change Locale',
+    ],
+    'permission' => [
+        'manage_translate_options' => [
+            'label' => 'Manage translation options.',
+            'tab' => 'Translate',
+        ],
+    ],
+    'settings' => [
+        'label' => 'Translate',
+        'description' => 'Manage translation options.',
+        'static_page_locale_routing' => [
+            'label' => 'Return 404 if translated page does not exist',
+            'comment' => 'Enable this to return a 404 if a static page does not have a locale URL defined.',
+        ],
+    ],
+];

--- a/models/Settings.php
+++ b/models/Settings.php
@@ -1,0 +1,10 @@
+<?php namespace AspenDigital\Translate\Models;
+
+use Model;
+
+class Settings extends Model
+{
+    public $implement = ['System.Behaviors.SettingsModel'];
+    public $settingsCode = 'aspendigital_translate_settings';
+    public $settingsFields = 'fields.yaml';
+}

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -1,0 +1,9 @@
+# ===================================
+#  Form Field Definitions
+# ===================================
+
+fields:
+    static_page_locale_routing:
+        label: Static Page Locale Routing
+        type: switch
+        comment: RainLab.Translate falls back to the default locale URL if unassigned in the active locale. This plugin overrides that behavior to return a 404 if a static page does not have a locale URL defined.

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -4,6 +4,6 @@
 
 fields:
     static_page_locale_routing:
-        label: Static Page Locale Routing
+        label: aspendigital.translate::lang.settings.static_page_locale_routing.label
         type: switch
-        comment: RainLab.Translate falls back to the default locale URL if unassigned in the active locale. This plugin overrides that behavior to return a 404 if a static page does not have a locale URL defined.
+        comment: aspendigital.translate::lang.settings.static_page_locale_routing.comment


### PR DESCRIPTION
Make 404 routing optional if page isn’t translated with current locale